### PR TITLE
Update Build and fix Snippets in TestApp

### DIFF
--- a/MonacoEditorComponent/Monaco/Languages/CompletionItem.cs
+++ b/MonacoEditorComponent/Monaco/Languages/CompletionItem.cs
@@ -68,7 +68,7 @@ namespace Monaco.Languages
         /// this completion.
         /// </summary>
         [JsonProperty("insertTextRules", NullValueHandling = NullValueHandling.Ignore)]
-        public int? InsertTextRules { get; set; }
+        public CompletionItemInsertTextRule? InsertTextRules { get; set; }
 
         /// <summary>
         /// The kind of this completion item. Based on the kind

--- a/MonacoEditorComponent/Monaco/Languages/CompletionItemInsertTextRule.cs
+++ b/MonacoEditorComponent/Monaco/Languages/CompletionItemInsertTextRule.cs
@@ -1,0 +1,11 @@
+﻿namespace Monaco.Languages
+{
+    /// <summary>
+    /// https://microsoft.github.io/monaco-editor/api/enums/monaco.languages.completioniteminserttextrule.html
+    /// </summary>
+    public enum CompletionItemInsertTextRule
+    {
+        KeepWhitespace = 1,
+        InsertAsSnippet = 4,
+    }
+}

--- a/MonacoEditorComponent/MonacoEditorComponent.csproj
+++ b/MonacoEditorComponent/MonacoEditorComponent.csproj
@@ -222,6 +222,11 @@
     <PackageReference Include="Microsoft.NETCore.UniversalWindowsPlatform">
       <Version>6.2.9</Version>
     </PackageReference>
+    <PackageReference Include="Microsoft.TypeScript.MSBuild">
+      <Version>3.7.4</Version>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+      <PrivateAssets>all</PrivateAssets>
+    </PackageReference>
     <PackageReference Include="Newtonsoft.Json">
       <Version>12.0.3</Version>
     </PackageReference>
@@ -267,9 +272,6 @@
     <VisualStudioVersion>14.0</VisualStudioVersion>
   </PropertyGroup>
   <Import Project="$(MSBuildExtensionsPath)\Microsoft\WindowsXaml\v$(VisualStudioVersion)\Microsoft.Windows.UI.Xaml.CSharp.targets" />
-  <PropertyGroup>
-    <PreBuildEvent>tsc -p "$(ProjectDir)ts-helpermethods"</PreBuildEvent>
-  </PropertyGroup>
   <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 
        Other similar extension points exist, see Microsoft.Common.targets.
   <Target Name="BeforeBuild">

--- a/MonacoEditorComponent/MonacoEditorComponent.csproj
+++ b/MonacoEditorComponent/MonacoEditorComponent.csproj
@@ -200,6 +200,7 @@
     <Compile Include="Monaco\Languages\Command.cs" />
     <Compile Include="Monaco\Languages\CompletionContext.cs" />
     <Compile Include="Monaco\Languages\CompletionItem.cs" />
+    <Compile Include="Monaco\Languages\CompletionItemInsertTextRule.cs" />
     <Compile Include="Monaco\Languages\CompletionItemKind.cs" />
     <Compile Include="Monaco\Languages\CompletionItemProvider.cs" />
     <Compile Include="Monaco\Languages\CompletionList.cs" />

--- a/MonacoEditorTestApp/Helpers/LanguageProvider.cs
+++ b/MonacoEditorTestApp/Helpers/LanguageProvider.cs
@@ -47,6 +47,9 @@ namespace MonacoEditorTestApp.Helpers
                     Suggestions = new[]
                     {
                         new CompletionItem("foreach", "foreach (var ${2:element} in ${1:array}) {\n\t$0\n}", CompletionItemKind.Snippet)
+                        {
+                            InsertTextRules = Monaco.Languages.CompletionItemInsertTextRule.InsertAsSnippet
+                        }
                     }
                 };
             });

--- a/README.md
+++ b/README.md
@@ -35,9 +35,9 @@ See [changelog](changelog.md) for more info.
 
 Build Notes
 -----------
-Built using Visual Studio 2017 for Windows 10 14393 and above.
+Built using Visual Studio 2019 for Windows 10 16299 and above.
 
-The **released** complete Monaco v0.13.0 build is used as a reference, this is not included in this repository and can be downloaded from the [Monaco site](https://microsoft.github.io/monaco-editor/).  The contents of its uncompressed 'package' directory should be placed in the *MonacoEditorComponent/monaco-editor* directory.  The `install-dependencies.ps1` PowerShell script can install this for you automatically.
+The **released** complete Monaco v0.19.3 build is used as a reference, this is not included in this repository and can be downloaded from the [Monaco site](https://microsoft.github.io/monaco-editor/).  The contents of its uncompressed 'package' directory should be placed in the *MonacoEditorComponent/monaco-editor* directory.  The `install-dependencies.ps1` PowerShell script can install this for you automatically.
 
 License
 -------

--- a/changelog.md
+++ b/changelog.md
@@ -9,6 +9,7 @@ v0.9 - 01/23/2020
 **Breaking changes**: 
 - Use StandaloneEditorConstructionOptions for Options instead of IEditorConstructionOptions
 - Use ClassName string instead of CssStyle type
+- Snippets need InsertTextRules property set to InsertAsSnippet
 
 v0.8.1 - 01/15/2019
 -------------------


### PR DESCRIPTION
Couple of tweaks to the PR. 😊

Uses the TypeScript NuGet for the build to simplify the required setup, seemed to work like a charm for me.

Also noticed there's a new Snippet property required in Monaco 0.19.3, so updated the Test app to use that and added the enum.